### PR TITLE
Add missing break to the extension lookup cycle.

### DIFF
--- a/native-deps-action/action.yml
+++ b/native-deps-action/action.yml
@@ -39,8 +39,10 @@ runs:
             search_pattern = "{}/*{}*{}".format(directory, libname, ext)
             print("Searching for pattern :", search_pattern)
             result = glob.glob(search_pattern)
+            print("Result :", result)
             if result:
               filepath = result[0]
+              break
 
         if not os.path.exists(filepath):
           print("Unable to find file for passed input")


### PR DESCRIPTION
This PR adds missing break statement to the `native-deps-action`, causing invalid behaviour in https://github.com/rnpgp/ruby-rnp/pull/79.

Fixes #77